### PR TITLE
added CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+# Owners for this repo
+*       @AndresPad @codebytes @msdpalam @neerajjhaveri  @MarcoABCardoso
+
+# Owners for cognitive service folder
+# /cognitive-services-landing-zone-in-a-box/*     
+
+# Owners for ml ops folder
+/ml-ops-in-a-box/*       @Welasco
+
+# Owners for semantic kernel folder
+/semantic-kernel-bot-in-a-box/*       @MarcoABCardoso


### PR DESCRIPTION
This pull request adds new owners for the repository by updating the `CODEOWNERS` file.

Main ownership changes:

* <a href="diffhunk://#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bR1-R11">`CODEOWNERS`</a>: Added new owners for the repository.