### PR TITLE
assistants: personal_finance example: fix missing calling_functions

### DIFF
--- a/gen-ai/Assistants/api-in-a-box/personal_finance/assistant-personal_finance.ipynb
+++ b/gen-ai/Assistants/api-in-a-box/personal_finance/assistant-personal_finance.ipynb
@@ -363,6 +363,7 @@
     "            break\n",
     "        if run.status == \"requires_action\":\n",
     "            # Handle function calling and continue processing\n",
+    "            call_functions(client, thread, run)\n",
     "            pass\n",
     "        else:\n",
     "            time.sleep(5)"


### PR DESCRIPTION
If you cloned the repo and try to call a function in the personal finance example, it might not work unless you call it in your process_prompt method.