### PR TITLE
Update requirements.txt

### DIFF
--- a/gen-ai/Assistants/api-in-a-box/requirements.txt
+++ b/gen-ai/Assistants/api-in-a-box/requirements.txt
@@ -1,4 +1,4 @@
-openai
+openai==1.10.0
 python-dotenv
 yfinance
 pillow


### PR DESCRIPTION
Set value to openai==1.10.0 to fix missing references to 

from openai.types.beta.threads.message_content_image_file import MessageContentImageFile
from openai.types.beta.threads.message_content_text import MessageContentText

here>>>

https://github.com/Azure/AI-in-a-Box/blob/main/gen-ai/Assistants/api-in-a-box/personal_finance/assistant-personal_finance.ipynb