### PR TITLE
Add instructions to enable SSO

### DIFF
--- a/gen-ai/Assistants/bot-in-a-box/README.md
+++ b/gen-ai/Assistants/bot-in-a-box/README.md
@@ -85,6 +85,48 @@ After running the deployment template, you may also run the application locally 
 - Send "clear" to delete the current thread;
 - Send "logout" to sign out when SSO is enabled;
 
+## Enabling SSO
+
+You can enable Single-Sign-On for your bot so that it identifies the user and keeps a token in context, that can later be used to retreive personal information like their name/job title, as well as for Microsoft Graph API calls.
+
+To enable SSO, follow the steps below. Please note that you should be an `Entra ID Application Developer` and a `Contributor` in the resource group in order to perform the following actions. You can also perform these steps in the portal if you prefer.
+
+- Load the required configurations. Hint: If you just deployed using Azure Developer CLI, you can run `azd env get-values` to retrieve these variables.
+```sh
+TENANT_ID=$(az account show --query tenantId -o tsv)
+APP_REGISTRATION_NAME=[choose app registration display name]
+AZURE_RESOURCE_GROUP_NAME=...
+BOT_NAME=...
+```
+
+- Create an App Registration and retrieve its ID and Client ID.
+```sh
+APP=$(az ad app create --display-name $APP_REGISTRATION_NAME --web-redirect-uris https://token.botframework.com/.auth/web/redirect)
+APP_ID=$(echo $APP | jq -r .id)
+CLIENT_ID=$(echo $APP | jq -r .appId)
+```
+- Create a client secret for the newly created app
+```sh
+SECRET=$(az ad app credential reset --id $APP_ID)
+CLIENT_SECRET=$(echo $SECRET | jq -r .password)
+```
+
+- Create an SSO configuration for your bot, passing in the App Registration details
+```sh
+az bot authsetting create --resource-group $AZURE_RESOURCE_GROUP_NAME --name $BOT_NAME --setting-name default --client-id $CLIENT_ID --client-secret $CLIENT_SECRET --parameters TenantId=$TENANT_ID --service aadv2 --provider-scope-string User.Read
+```
+
+- Configure the App Service to use the SSO configuration.
+```sh
+az webapp config appsettings set -g $AZURE_RESOURCE_GROUP_NAME -n $APP_NAME --settings SSO_ENABLED=true SSO_CONFIG_NAME=default
+```
+
+- Clear sensitive variables from terminal
+```sh
+SECRET=
+CLIENT_SECRET=
+```
+
 ### Enabling Web Chat
 
 To deploy a Web Chat version of your app:

--- a/gen-ai/Assistants/bot-in-a-box/infra/main.bicep
+++ b/gen-ai/Assistants/bot-in-a-box/infra/main.bicep
@@ -142,3 +142,4 @@ output AOAI_NAME string = m_openai.outputs.openaiName
 output AOAI_API_ENDPOINT string = m_openai.outputs.openaiEndpoint
 output APP_NAME string = m_app.outputs.appName
 output APP_HOSTNAME string = m_app.outputs.hostName
+output BOT_NAME string = m_bot.outputs.name

--- a/gen-ai/Assistants/bot-in-a-box/infra/modules/botservice.bicep
+++ b/gen-ai/Assistants/bot-in-a-box/infra/modules/botservice.bicep
@@ -27,3 +27,5 @@ resource botservice 'Microsoft.BotService/botServices@2022-09-15' = {
   }
 
 }
+
+output name string = botservice.name

--- a/gen-ai/semantic-kernel-bot-in-a-box/README.md
+++ b/gen-ai/semantic-kernel-bot-in-a-box/README.md
@@ -109,6 +109,48 @@ To create a custom plugin:
 
 And you're done! Redeploy your app and Semantic Kernel will now use your plugin whenever the user's questions call for it.
 
+## Enabling SSO
+
+You can enable Single-Sign-On for your bot so that it identifies the user and keeps a token in context, that can later be used to retreive personal information like their name/job title, as well as for Microsoft Graph API calls.
+
+To enable SSO, follow the steps below. Please note that you should be an `Entra ID Application Developer` and a `Contributor` in the resource group in order to perform the following actions. You can also perform these steps in the portal if you prefer.
+
+- Load the required configurations. Hint: If you just deployed using Azure Developer CLI, you can run `azd env get-values` to retrieve these variables.
+```sh
+TENANT_ID=$(az account show --query tenantId -o tsv)
+APP_REGISTRATION_NAME=[choose app registration display name]
+AZURE_RESOURCE_GROUP_NAME=...
+BOT_NAME=...
+```
+
+- Create an App Registration and retrieve its ID and Client ID.
+```sh
+APP=$(az ad app create --display-name $APP_REGISTRATION_NAME --web-redirect-uris https://token.botframework.com/.auth/web/redirect)
+APP_ID=$(echo $APP | jq -r .id)
+CLIENT_ID=$(echo $APP | jq -r .appId)
+```
+- Create a client secret for the newly created app
+```sh
+SECRET=$(az ad app credential reset --id $APP_ID)
+CLIENT_SECRET=$(echo $SECRET | jq -r .password)
+```
+
+- Create an SSO configuration for your bot, passing in the App Registration details
+```sh
+az bot authsetting create --resource-group $AZURE_RESOURCE_GROUP_NAME --name $BOT_NAME --setting-name default --client-id $CLIENT_ID --client-secret $CLIENT_SECRET --parameters TenantId=$TENANT_ID --service aadv2 --provider-scope-string User.Read
+```
+
+- Configure the App Service to use the SSO configuration.
+```sh
+az webapp config appsettings set -g $AZURE_RESOURCE_GROUP_NAME -n $APP_NAME --settings SSO_ENABLED=true SSO_CONFIG_NAME=default
+```
+
+- Clear sensitive variables from terminal
+```sh
+SECRET=
+CLIENT_SECRET=
+```
+
 ## Enabling Web Chat
 
 To deploy a Web Chat version of your app:

--- a/gen-ai/semantic-kernel-bot-in-a-box/infra/main.bicep
+++ b/gen-ai/semantic-kernel-bot-in-a-box/infra/main.bicep
@@ -206,3 +206,6 @@ output AZURE_SEARCH_ENDPOINT string = deploySearch ? m_search.outputs.searchEndp
 output AZURE_SEARCH_NAME string = deploySearch ? m_search.outputs.searchName : ''
 output AZURE_RESOURCE_GROUP_ID string = resourceGroup.id
 output AZURE_RESOURCE_GROUP_NAME string = resourceGroup.name
+output APP_NAME string = m_app.outputs.appName
+output APP_HOSTNAME string = m_app.outputs.hostName
+output BOT_NAME string = m_bot.outputs.name

--- a/gen-ai/semantic-kernel-bot-in-a-box/infra/modules/appservice.bicep
+++ b/gen-ai/semantic-kernel-bot-in-a-box/infra/modules/appservice.bicep
@@ -217,4 +217,5 @@ resource appService 'Microsoft.Web/sites@2022-09-01' = {
   }
 }
 
+output appName string = appService.name
 output hostName string = appService.properties.defaultHostName

--- a/gen-ai/semantic-kernel-bot-in-a-box/infra/modules/botservice.bicep
+++ b/gen-ai/semantic-kernel-bot-in-a-box/infra/modules/botservice.bicep
@@ -28,3 +28,4 @@ resource botservice 'Microsoft.BotService/botServices@2022-09-15' = {
 
 }
 
+output name string = botservice.name

--- a/gen-ai/semantic-kernel-bot-in-a-box/src/.editorconfig
+++ b/gen-ai/semantic-kernel-bot-in-a-box/src/.editorconfig
@@ -1,4 +1,4 @@
 [*.cs]
-dotnet_diagnostic.SKEXP0011.severity = none
+dotnet_diagnostic.SKEXP0010.severity = none
 dotnet_diagnostic.SKEXP0060.severity = none
 dotnet_diagnostic.SKEXP0061.severity = none

--- a/gen-ai/semantic-kernel-bot-in-a-box/src/AdapterWithErrorHandler.cs
+++ b/gen-ai/semantic-kernel-bot-in-a-box/src/AdapterWithErrorHandler.cs
@@ -26,6 +26,7 @@ namespace Microsoft.BotBuilderSamples
                 // Send a message to the user
                 await turnContext.SendActivityAsync("The bot encountered an error or bug.");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+                await turnContext.SendActivityAsync(exception.Message);
 
                 if (conversationState != null)
                 {

--- a/gen-ai/semantic-kernel-bot-in-a-box/src/Bots/SemanticKernelBot.cs
+++ b/gen-ai/semantic-kernel-bot-in-a-box/src/Bots/SemanticKernelBot.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text.Json;
 using Azure.AI.FormRecognizer.DocumentAnalysis;
 using Azure.AI.OpenAI;
 using Azure.Search.Documents;
@@ -112,7 +113,7 @@ namespace Microsoft.BotBuilderSamples
 
             if (_useStepwisePlanner)
             {
-                var plannerOptions = new FunctionCallingStepwisePlannerConfig
+                var plannerOptions = new FunctionCallingStepwisePlannerOptions
                 {
                     MaxTokens = 128000,
                 };
@@ -120,15 +121,13 @@ namespace Microsoft.BotBuilderSamples
                 var planner = new FunctionCallingStepwisePlanner(plannerOptions);
                 string prompt = FormatConversationHistory(conversationData);
                 var result = await planner.ExecuteAsync(kernel, prompt);
+                await turnContext.SendActivityAsync(JsonSerializer.Serialize(result));
 
                 return result.FinalAnswer;
             }
             else
             {
-                var plannerOptions = new HandlebarsPlannerOptions
-                {
-                    MaxTokens = 128000,
-                };
+                var plannerOptions = new HandlebarsPlannerOptions();
 
                 var planner = new HandlebarsPlanner(plannerOptions);
                 string prompt = FormatConversationHistory(conversationData);

--- a/gen-ai/semantic-kernel-bot-in-a-box/src/Bots/SemanticKernelBot.cs
+++ b/gen-ai/semantic-kernel-bot-in-a-box/src/Bots/SemanticKernelBot.cs
@@ -121,7 +121,6 @@ namespace Microsoft.BotBuilderSamples
                 var planner = new FunctionCallingStepwisePlanner(plannerOptions);
                 string prompt = FormatConversationHistory(conversationData);
                 var result = await planner.ExecuteAsync(kernel, prompt);
-                await turnContext.SendActivityAsync(JsonSerializer.Serialize(result));
 
                 return result.FinalAnswer;
             }

--- a/gen-ai/semantic-kernel-bot-in-a-box/src/Bots/StateManagementBot.cs
+++ b/gen-ai/semantic-kernel-bot-in-a-box/src/Bots/StateManagementBot.cs
@@ -31,10 +31,10 @@ namespace Microsoft.BotBuilderSamples
             _conversationState = conversationState;
             _userState = userState;
             _dialog = dialog;
-            _max_messages = config.GetValue<int?>("CONVERSATION_HISTORY_MAX_MESSAGES") ?? 10;
-            _max_attachments = config.GetValue<int?>("MAX_ATTACHMENTS") ?? 5;
-            _sso_enabled = config.GetValue<bool?>("SSO_ENABLED") ?? false;
-            _sso_config_name = config.GetValue<string?>("SSO_CONFIG_NAME");
+            _max_messages = config.GetValue("CONVERSATION_HISTORY_MAX_MESSAGES", 10);
+            _max_attachments = config.GetValue("MAX_ATTACHMENTS", 5);
+            _sso_enabled = config.GetValue("SSO_ENABLED", false);
+            _sso_config_name = config.GetValue("SSO_CONFIG_NAME", "default");
         }
 
         public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))

--- a/gen-ai/semantic-kernel-bot-in-a-box/src/SemanticKernelBot.csproj
+++ b/gen-ai/semantic-kernel-bot-in-a-box/src/SemanticKernelBot.csproj
@@ -18,12 +18,12 @@
     <PackageReference Include="Microsoft.Bot.Builder.Azure.Blobs" Version="4.20.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.21.2" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.20.1" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageReference Include="Microsoft.Graph" Version="5.38.0" />
     <PackageReference Include="Microsoft.Graph.Core" Version="3.1.4" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.0.1" />
-    <PackageReference Include="Microsoft.SemanticKernel.Planners.Handlebars" Version="1.0.1-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Planners.OpenAI" Version="1.0.1-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.6.3" />
+    <PackageReference Include="Microsoft.SemanticKernel.Planners.Handlebars" Version="1.6.3-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Planners.OpenAI" Version="1.6.3-preview" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Adds instructions for adding SSO to your bots.
Applies to both Semantic Kernel and Assistant bot accelerators.